### PR TITLE
Sunsdr2pro

### DIFF
--- a/Project Files/Source/ChannelMaster/network.c
+++ b/Project Files/Source/ChannelMaster/network.c
@@ -102,16 +102,16 @@ int nativeInitMetis(char* netaddr, int port, char* localaddr, int localport, int
 
 	/* SunSDR native protocol — bypass HPSDR socket setup entirely.
 	 *
-	 * Honour the radio's configured control port (from the Setup
-	 * `Fixed listen port` field or the discovered RadioInfo) so
-	 * operators who changed the port from the 50001 default can
-	 * still connect. Stream port is control port + 1, matching
-	 * the SunSDR2 DX 50001/50002 pairing convention.
-	 * Closes issue #15. */
+	 * Prefer the explicit UI-selected model when choosing defaults so DX
+	 * and PRO each get their own bootstrap profile. If the operator (or
+	 * discovery result) provides a control port, honour it and derive the
+	 * stream port from that runtime port pair. */
 	if (protocol == SUNSDR) {
-		int sunsdr_ctrl = (port > 0) ? port : SUNSDR_CONTROL_PORT;
-		int sunsdr_stream = (port > 0) ? (port + 1) : SUNSDR_STREAM_PORT;
-		return SunSDRInit(netaddr, sunsdr_ctrl, sunsdr_stream);
+		int default_ctrl = (model_id == HPSDRModel_SUNSDR2PRO) ? 50002 : SUNSDR_CONTROL_PORT;
+		int default_stream = (model_id == HPSDRModel_SUNSDR2PRO) ? 50003 : SUNSDR_STREAM_PORT;
+		int sunsdr_ctrl = (port > 0) ? port : default_ctrl;
+		int sunsdr_stream = (port > 0) ? (port + 1) : default_stream;
+		return SunSDRInit(netaddr, sunsdr_ctrl, sunsdr_stream, model_id);
 	}
 
 	prn->base_outbound_port = port;
@@ -1521,7 +1521,7 @@ DWORD WINAPI KeepAliveMain(LPVOID n) {
 
 PORT int nativeSunSDRInit(char* radioIP, int ctrlPort, int streamPort)
 {
-	return SunSDRInit(radioIP, ctrlPort, streamPort);
+	return SunSDRInit(radioIP, ctrlPort, streamPort, HPSDRModel);
 }
 
 PORT void nativeSunSDRDestroy(void)

--- a/Project Files/Source/ChannelMaster/network.c
+++ b/Project Files/Source/ChannelMaster/network.c
@@ -102,10 +102,14 @@ int nativeInitMetis(char* netaddr, int port, char* localaddr, int localport, int
 
 	/* SunSDR native protocol — bypass HPSDR socket setup entirely.
 	 *
+	 * Honour the radio's configured control port (from the Setup
+	 * `Fixed listen port` field or the discovered RadioInfo) so
+	 * operators who changed the port from the default can still connect.
+	 * Stream port is control port + 1, matching the original SunSDR2 DX
+	 * 50001/50002 pairing convention. Closes issue #15.
+	 *
 	 * Prefer the explicit UI-selected model when choosing defaults so DX
-	 * and PRO each get their own bootstrap profile. If the operator (or
-	 * discovery result) provides a control port, honour it and derive the
-	 * stream port from that runtime port pair. */
+	 * and PRO each get their own bootstrap profile and default port pair. */
 	if (protocol == SUNSDR) {
 		int default_ctrl = (model_id == HPSDRModel_SUNSDR2PRO) ? 50002 : SUNSDR_CONTROL_PORT;
 		int default_stream = (model_id == HPSDRModel_SUNSDR2PRO) ? 50003 : SUNSDR_STREAM_PORT;

--- a/Project Files/Source/ChannelMaster/network.h
+++ b/Project Files/Source/ChannelMaster/network.h
@@ -422,7 +422,7 @@ enum HPSDRHW
 	HermesLite = 6,  // MI0BOT: HL2 allocated number
 	Saturn = 10,     // ANAN-G2: added G8NJJ
 	SaturnMKII = 11, // ANAN-G2: MKII board
-	SunSDR = 20      // SunSDR2 DX
+	SunSDR = 20      // SunSDR2 native
 };
 
 enum _HPSDRModel //from enums.cs
@@ -443,7 +443,8 @@ enum _HPSDRModel //from enums.cs
 	HPSDRModel_ANVELINAPRO3 = 13,
 	HPSDRModel_HERMESLITE = 14,
 	HPSDRModel_REDPITAYA = 15,
-	HPSDRModel_SUNSDR2DX = 16
+	HPSDRModel_SUNSDR2DX = 16,
+	HPSDRModel_SUNSDR2PRO = 17
 } HPSDRModel;
 
 enum _RadioProtocol

--- a/Project Files/Source/ChannelMaster/network.h
+++ b/Project Files/Source/ChannelMaster/network.h
@@ -422,7 +422,7 @@ enum HPSDRHW
 	HermesLite = 6,  // MI0BOT: HL2 allocated number
 	Saturn = 10,     // ANAN-G2: added G8NJJ
 	SaturnMKII = 11, // ANAN-G2: MKII board
-	SunSDR = 20      // SunSDR2 native
+	SunSDR = 20      // SunSDR2 DX/PRO native
 };
 
 enum _HPSDRModel //from enums.cs

--- a/Project Files/Source/ChannelMaster/sunsdr.c
+++ b/Project Files/Source/ChannelMaster/sunsdr.c
@@ -1126,9 +1126,9 @@ static void sunsdr_cache_identity_candidate(const unsigned char* data, int len, 
 /* ========== Resampler: 39.0625 kHz packet IQ → Thetis RX rate ========== */
 
 /* DX now feeds xrouter natively at 312.5 kHz (upstream v2.0.8 path).
- * PRO still needs the older 39.0625 kHz -> 384 kHz upsample stage to
- * keep FM audio correct. Keep the resampler only for non-native-rate
- * profiles. */
+ * PRO shares the same wire-IQ packet format and display path, so it must
+ * use the same native router rate. Keep the resampler only for any future
+ * non-native profile. */
 #define SUNSDR_TARGET_RATE   384000.0
 #define SUNSDR_RESAMPLE_MAX  2048 /* 200 * 384000 / 39062.5 = 1966.08 */
 
@@ -2211,7 +2211,7 @@ static const char* SUNSDR_STATE_SYNC_TEMPLATE_HEX =
     "32ff01003200000000000100000000000000320000003200000032000000320000003200000032000000320000003200000000000000010003000300322af87f000028f8";
 
 static const char* SUNSDR_PRO_STATE_SYNC_TEMPLATE_HEX =
-    "32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010000000000a23cfc7f00008859";
+    "32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010003000300a23cfc7f00008859";
 
 static const char* SUNSDR_CONFIG_BLOCK_TEMPLATE_HEX =
     "32ff20003400000000000100000000000000010000000100000000000000000000006400000000000000000000001e000000bc02000007000000640000002c01000064000000";
@@ -2460,7 +2460,7 @@ static const sunsdr_macro_step_t power_on_macro_pro[] = {
     {"32ff1800040000000000010000000000000000000000", 22, 300},
     {"32ff19000400000000000100000000000000ff000000", 22, 300},
     {"32ff2100040000000000010000000000000000000000", 22, 300},
-    {"32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010000000000a23cfc7f00008859", 68, 300},
+    {"32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010003000300a23cfc7f00008859", 68, 300},
     {"32ff0900080000000000010000000000000060fd4d0400000000", 26, 300},
     {"32ff0800080000000000010000000000000098f35b0400000000", 26, 300},
     {"32ff08000800010000000100000000000000c058510400000000", 26, 300},
@@ -2472,7 +2472,7 @@ static const sunsdr_profile_t sunsdr_profile_dx = {
 };
 
 static const sunsdr_profile_t sunsdr_profile_pro = {
-    SUNSDR_VARIANT_PRO, "SunSDR2 PRO", 50002, 50003, 0x01, 39062.5, 0, 0
+    SUNSDR_VARIANT_PRO, "SunSDR2 PRO", 50002, 50003, 0x01, 312500.0, 0, 0
 };
 
 static const sunsdr_profile_t* sunsdr_profile_from_model(int modelId)
@@ -2949,8 +2949,8 @@ int SunSDRPowerOn(void)
     sdr.txPrevQ = 0.0;
     sdr.txAccumCount = 0;
 
-    /* PRO still uses the legacy RX upsample stage; clear its phase when a
-     * session starts so stale interpolation state cannot bleed across runs. */
+    /* Clear resampler state when a session starts so stale interpolation
+     * history cannot bleed across runs. */
     memset(resampler, 0, sizeof(resampler));
 
     /* Dump audio state BEFORE any fixes */
@@ -4374,8 +4374,7 @@ DWORD WINAPI SunSDRReadThread(LPVOID param)
                                payload[k + 0] << 8));     /* Q (bytes 0-2) */
         }
 
-        /* DX feeds WDSP natively at 312.5 kHz; PRO keeps the legacy
-         * resample step to 384 kHz. */
+        /* DX/PRO both feed WDSP natively at 312.5 kHz. */
         {
             int active_sources = pktbuf[8];
             int source = 0;

--- a/Project Files/Source/ChannelMaster/sunsdr.c
+++ b/Project Files/Source/ChannelMaster/sunsdr.c
@@ -1,6 +1,6 @@
 /*  sunsdr.c
 
-SunSDR2 DX native protocol implementation for Thetis.
+SunSDR2 native protocol implementation for Thetis.
 
 All SunSDR-specific protocol logic is contained in this file.
 This includes: discovery, bootstrap, power on/off, frequency,
@@ -56,6 +56,11 @@ static void sunsdr_build_tx_packet(unsigned char* buf, unsigned int seq, const d
 static void sunsdr_send_tx_packet(const double* iq);
 static struct sockaddr_in sunsdr_stream_dest(void);
 static void sunsdr_dbg_note_tx_packet(unsigned int seq);
+static unsigned char sunsdr_magic0(void);
+static int sunsdr_is_pro(void);
+static int sunsdr_freq_is_vhf(int freqHz);
+static const char* sunsdr_state_sync_template_hex(void);
+static const sunsdr_macro_step_t* sunsdr_power_on_macro(void);
 
 /* sunsdr_debug.log writer (sdr_logf path) and per-attempt IQ dumps.
  * Both disabled in production. Flip to 1 only when actively
@@ -66,6 +71,16 @@ static void sunsdr_dbg_note_tx_packet(unsigned int seq);
 /* Global SunSDR session state — moved above the iq_dump / tx_pace
  * helpers which need sdr.currentPTT, sdr.streamSock, sdr.txSeq, etc. */
 static sunsdr_state_t sdr;
+
+static unsigned char sunsdr_magic0(void)
+{
+    return (sdr.profile != NULL) ? sdr.profile->magic0 : SUNSDR_MAGIC_0;
+}
+
+static int sunsdr_is_pro(void)
+{
+    return sdr.profile != NULL && sdr.profile->variant == SUNSDR_VARIANT_PRO;
+}
 
 /* TX IQ ground-truth recorder.
  *
@@ -1013,7 +1028,7 @@ static void sunsdr_try_parse_identity_011a(const unsigned char* data, int len, c
         return;
     }
 
-    if (data[0] != 0x32 || data[1] != 0xFF || data[2] != 0x01 || data[3] != 0x1A) {
+    if (data[0] != sunsdr_magic0() || data[1] != 0xFF || data[2] != 0x01 || data[3] != 0x1A) {
         return;
     }
 
@@ -1041,7 +1056,7 @@ static void sunsdr_try_parse_serial_from_fwmgr(const unsigned char* data, int le
         return;
     }
 
-    if (data[0] != 0x32 || data[1] != 0xFF || data[2] != 0x1A || data[4] != 0x20 || data[5] != 0x00) {
+    if (data[0] != sunsdr_magic0() || data[1] != 0xFF || data[2] != 0x1A || data[4] != 0x20 || data[5] != 0x00) {
         return;
     }
 
@@ -1108,15 +1123,24 @@ static void sunsdr_cache_identity_candidate(const unsigned char* data, int len, 
     }
 }
 
-/* ========== RX IQ rate ========== */
-/*
- * SunSDR delivers native 312,500 Hz IQ (200 complex samples per 0xFE packet).
- * We feed xrouter directly at that rate — WDSP runs natively at 312.5 kHz
- * and rmatch handles the final 312500 → 48000 Hz drop to audio. No
- * intermediate upsample stage; removed 2026-04-22 on feature/native-312k-rate
- * to eliminate the linear-interp resampler that was aliasing strong
- * out-of-window signals into the display band (GH #26).
- */
+/* ========== Resampler: 39.0625 kHz packet IQ → Thetis RX rate ========== */
+
+/* DX now feeds xrouter natively at 312.5 kHz (upstream v2.0.8 path).
+ * PRO still needs the older 39.0625 kHz -> 384 kHz upsample stage to
+ * keep FM audio correct. Keep the resampler only for non-native-rate
+ * profiles. */
+#define SUNSDR_TARGET_RATE   384000.0
+#define SUNSDR_RESAMPLE_MAX  2048 /* 200 * 384000 / 39062.5 = 1966.08 */
+
+typedef struct _sunsdr_resampler_state
+{
+    double phase;
+    double prev_I;
+    double prev_Q;
+    double out[SUNSDR_RESAMPLE_MAX * 2];
+} sunsdr_resampler_state_t;
+
+static sunsdr_resampler_state_t resampler[2];
 
 /*
  * TX IQ stream rate. From live ExpertSDR3 voice MOX capture, the host sends
@@ -1131,6 +1155,61 @@ static void sunsdr_cache_identity_candidate(const unsigned char* data, int len, 
 #define SUNSDR_TX_OUTPUT_RATE  39062.5
 #define SUNSDR_TX_RESAMPLE_STEP (SUNSDR_TX_INPUT_RATE / SUNSDR_TX_OUTPUT_RATE)  /* ~4.9152 */
 
+/*
+ * Resample nsamples complex pairs from in[] to resample_out[].
+ * Returns number of complex output samples produced.
+ * Uses linear interpolation with state preserved across calls.
+ */
+static int sunsdr_resample(int source, const double* in, int nsamples)
+{
+    int out_count = 0;
+    int i;
+    sunsdr_resampler_state_t* rs = &resampler[source];
+    double prev_I = rs->prev_I;
+    double prev_Q = rs->prev_Q;
+    double native_rate = (sdr.profile != NULL && sdr.profile->rxNativeRate > 1.0)
+        ? sdr.profile->rxNativeRate
+        : 39062.5;
+    double resample_step = native_rate / SUNSDR_TARGET_RATE;
+
+    for (i = 0; i < nsamples; i++) {
+        double cur_I = in[2 * i + 0];
+        double cur_Q = in[2 * i + 1];
+
+        /* Emit output samples while phase < 1.0 (we're within this input interval) */
+        while (rs->phase < 1.0 && out_count < SUNSDR_RESAMPLE_MAX) {
+            double frac = rs->phase;
+            rs->out[2 * out_count + 0] = prev_I + frac * (cur_I - prev_I);
+            rs->out[2 * out_count + 1] = prev_Q + frac * (cur_Q - prev_Q);
+            out_count++;
+            rs->phase += resample_step;
+        }
+        rs->phase -= 1.0;
+
+        prev_I = cur_I;
+        prev_Q = cur_Q;
+    }
+
+    rs->prev_I = prev_I;
+    rs->prev_Q = prev_Q;
+
+    return out_count;
+}
+
+static int sunsdr_rx_uses_native_router_rate(void)
+{
+    return sdr.profile != NULL && fabs(sdr.profile->rxNativeRate - 312500.0) < 1.0;
+}
+
+static int sunsdr_rx_router_feed_size(void)
+{
+    return sunsdr_rx_uses_native_router_rate() ? SUNSDR_IQ_COMPLEX_PER_PKT : 1966;
+}
+
+static double sunsdr_rx_packet_rate(void)
+{
+    return sunsdr_rx_uses_native_router_rate() ? 1562.5 : 195.3125;
+}
 /* ========== Helpers ========== */
 
 static const double NORM = 1.0 / 2147483648.0;
@@ -1452,7 +1531,7 @@ static int sunsdr_quantize24(double sample)
 static void sunsdr_build_iq_header(unsigned char* buf, int opcode, unsigned int seq, unsigned char byte8, unsigned char byte9)
 {
     memset(buf, 0, SUNSDR_IQ_PKT_SIZE);
-    buf[0] = SUNSDR_MAGIC_0;
+    buf[0] = sunsdr_magic0();
     buf[1] = SUNSDR_MAGIC_1;
     buf[2] = (unsigned char)opcode;
     buf[3] = 0xFF;
@@ -1874,11 +1953,20 @@ static int sunsdr_parse_hex(const char* hex, unsigned char* buf, int maxlen)
     return len;
 }
 
+static void sunsdr_patch_magic(unsigned char* pkt, int len)
+{
+    if (pkt != NULL && len > 0) {
+        pkt[0] = sunsdr_magic0();
+    }
+}
+
 static void sunsdr_send_hex_pkt_u8(const char* hex, int offset, unsigned char value)
 {
     unsigned char pkt[128];
     unsigned char reply[128];
     int len = sunsdr_parse_hex(hex, pkt, (int)sizeof(pkt));
+
+    sunsdr_patch_magic(pkt, len);
 
     if (offset >= 0 && offset < len)
         pkt[offset] = value;
@@ -1894,6 +1982,8 @@ static void sunsdr_send_hex_pkt(const char* hex, int len_hint)
 
     if (len_hint > 0 && len_hint < len)
         len = len_hint;
+
+    sunsdr_patch_magic(pkt, len);
 
     sunsdr_send_ctrl_and_recv(pkt, len, reply, (int)sizeof(reply));
 }
@@ -1947,7 +2037,7 @@ static void sunsdr_drain_control_socket(const char* label)
 static void sunsdr_build_header(unsigned char* buf, int opcode, int sub, int decl_len)
 {
     memset(buf, 0, SUNSDR_CTL_HDR_SIZE);
-    buf[0] = SUNSDR_MAGIC_0;
+    buf[0] = sunsdr_magic0();
     buf[1] = SUNSDR_MAGIC_1;
     buf[2] = (unsigned char)opcode;
     buf[3] = 0x00;
@@ -2120,6 +2210,9 @@ static void sunsdr_send_zero_cmd(int opcode)
 static const char* SUNSDR_STATE_SYNC_TEMPLATE_HEX =
     "32ff01003200000000000100000000000000320000003200000032000000320000003200000032000000320000003200000000000000010003000300322af87f000028f8";
 
+static const char* SUNSDR_PRO_STATE_SYNC_TEMPLATE_HEX =
+    "32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010000000000a23cfc7f00008859";
+
 static const char* SUNSDR_CONFIG_BLOCK_TEMPLATE_HEX =
     "32ff20003400000000000100000000000000010000000100000000000000000000006400000000000000000000001e000000bc02000007000000640000002c01000064000000";
 
@@ -2213,7 +2306,10 @@ static void sunsdr_send_band_change_prelude(int toVhf)
 
 static void sunsdr_send_state_sync_count(int rx_count)
 {
-    sunsdr_send_hex_pkt_u8(SUNSDR_STATE_SYNC_TEMPLATE_HEX, 0x36, (unsigned char)rx_count);
+    if (sunsdr_is_pro())
+        sunsdr_send_hex_pkt(sunsdr_state_sync_template_hex(), 68);
+    else
+        sunsdr_send_hex_pkt_u8(sunsdr_state_sync_template_hex(), 0x36, (unsigned char)rx_count);
 }
 
 static void sunsdr_send_config_block_state(int rx_state)
@@ -2318,11 +2414,7 @@ static void sunsdr_reconfigure_rx_paths(int rx2_enabled)
 /* ========== Bootstrap + Power-On Macro ========== */
 
 /* control_ready_v2 macro - validated 2026-04-07 */
-static const struct {
-    const char* hex;
-    int len;
-    int delay_us; /* microseconds */
-} power_on_macro[] = {
+static const sunsdr_macro_step_t power_on_macro_dx[] = {
     /* Bootstrap: primer_minimal */
     {"32ff5a000000000000000100000000000000", 18, 50000},
     {"32ff1800040000000000010000000000000000000000", 22, 50000},
@@ -2360,6 +2452,63 @@ static const struct {
     {NULL, 0, 0} /* sentinel */
 };
 
+static const sunsdr_macro_step_t power_on_macro_pro[] = {
+    {"32ff1800040000000000010000000000000000000000", 22, 300},
+    {"32ff1d00040000000000010000000000000000000000", 22, 300},
+    {"32ff1b00040000000000010000000000000000000000", 22, 300},
+    {"32ff0500040000000000010000000000000000000000", 22, 300},
+    {"32ff1800040000000000010000000000000000000000", 22, 300},
+    {"32ff19000400000000000100000000000000ff000000", 22, 300},
+    {"32ff2100040000000000010000000000000000000000", 22, 300},
+    {"32ff01003200000000000100000000000000140000001400000014000000140000001400000014000000140000001400000000000000010000000000a23cfc7f00008859", 68, 300},
+    {"32ff0900080000000000010000000000000060fd4d0400000000", 26, 300},
+    {"32ff0800080000000000010000000000000098f35b0400000000", 26, 300},
+    {"32ff08000800010000000100000000000000c058510400000000", 26, 300},
+    {NULL, 0, 0} /* sentinel */
+};
+
+static const sunsdr_profile_t sunsdr_profile_dx = {
+    SUNSDR_VARIANT_DX, "SunSDR2 DX", 50001, 50002, 0x32, 312500.0, -1, -1
+};
+
+static const sunsdr_profile_t sunsdr_profile_pro = {
+    SUNSDR_VARIANT_PRO, "SunSDR2 PRO", 50002, 50003, 0x01, 39062.5, 0, 0
+};
+
+static const sunsdr_profile_t* sunsdr_profile_from_model(int modelId)
+{
+    switch (modelId) {
+    case HPSDRModel_SUNSDR2PRO:
+        return &sunsdr_profile_pro;
+    case HPSDRModel_SUNSDR2DX:
+        return &sunsdr_profile_dx;
+    default:
+        return NULL;
+    }
+}
+
+static const sunsdr_profile_t* sunsdr_pick_profile(int modelId, int ctrlPort, int streamPort)
+{
+    const sunsdr_profile_t* explicit_profile = sunsdr_profile_from_model(modelId);
+    if (explicit_profile != NULL)
+        return explicit_profile;
+
+    if (ctrlPort == sunsdr_profile_pro.defaultCtrlPort ||
+        streamPort == sunsdr_profile_pro.defaultStreamPort)
+        return &sunsdr_profile_pro;
+    return &sunsdr_profile_dx;
+}
+
+static const char* sunsdr_state_sync_template_hex(void)
+{
+    return sunsdr_is_pro() ? SUNSDR_PRO_STATE_SYNC_TEMPLATE_HEX : SUNSDR_STATE_SYNC_TEMPLATE_HEX;
+}
+
+static const sunsdr_macro_step_t* sunsdr_power_on_macro(void)
+{
+    return sunsdr_is_pro() ? power_on_macro_pro : power_on_macro_dx;
+}
+
 static int sunsdr_run_macro(void)
 {
     unsigned char pkt[128];
@@ -2368,10 +2517,15 @@ static int sunsdr_run_macro(void)
 
     sunsdr_set_ctrl_trace_label("macro");
 
-    for (i = 0; power_on_macro[i].hex != NULL; i++) {
-        int len = power_on_macro[i].len;
+    for (i = 0; ; i++) {
+        const sunsdr_macro_step_t* step = &sunsdr_power_on_macro()[i];
+        const char* hex = step->hex;
+        int len = step->len;
+        int delay_us = step->delay_us;
         int j;
         char step_label[32];
+
+        if (hex == NULL) break;
 
         _snprintf(step_label, sizeof(step_label), "macro[%02d]", i + 1);
         step_label[sizeof(step_label) - 1] = '\0';
@@ -2380,16 +2534,30 @@ static int sunsdr_run_macro(void)
         /* Parse hex string to bytes */
         for (j = 0; j < len && j < (int)sizeof(pkt); j++) {
             unsigned int byte;
-            sscanf(power_on_macro[i].hex + j * 2, "%02x", &byte);
+            sscanf(hex + j * 2, "%02x", &byte);
             pkt[j] = (unsigned char)byte;
+        }
+        if (len > 0) pkt[0] = sunsdr_magic0();
+
+        if (len >= 68 && pkt[1] == 0xff && pkt[2] == 0x01) {
+            len = sunsdr_parse_hex(sunsdr_state_sync_template_hex(), pkt, (int)sizeof(pkt));
+            sunsdr_patch_magic(pkt, len);
+        }
+
+        if (sdr.profile->macroStartIqValue >= 0 &&
+            len >= 22 && pkt[1] == 0xff && pkt[2] == SUNSDR_OP_START_IQ) {
+            pkt[18] = (unsigned char)(sdr.profile->macroStartIqValue & 0xFF);
+            pkt[19] = 0;
+            pkt[20] = 0;
+            pkt[21] = 0;
         }
 
         /* Patch the mic-source packet (OP 0x21) at byte 18 to carry the
          * user's saved mic source, instead of the hardcoded 1 (Mic2) that
          * the baked macro string contains. This keeps the init macro's
          * exact structure while honouring the saved user preference. */
-        if (len >= 22 && pkt[0] == 0x32 && pkt[1] == 0xff && pkt[2] == 0x21) {
-            pkt[18] = (unsigned char)(sdr.currentMicSource & 0xFF);
+        if (len >= 22 && pkt[0] == sunsdr_magic0() && pkt[1] == 0xff && pkt[2] == 0x21) {
+            pkt[18] = (unsigned char)((sdr.profile->macroMicSourceValue >= 0) ? sdr.profile->macroMicSourceValue : sdr.currentMicSource);
             pkt[19] = 0;
             pkt[20] = 0;
             pkt[21] = 0;
@@ -2397,9 +2565,9 @@ static int sunsdr_run_macro(void)
 
         sunsdr_send_ctrl_and_recv(pkt, len, reply, sizeof(reply));
 
-        if (power_on_macro[i].delay_us > 0) {
+        if (delay_us > 0) {
             /* Sleep in microseconds (Windows minimum is ~1ms) */
-            int ms = power_on_macro[i].delay_us / 1000;
+            int ms = delay_us / 1000;
             if (ms < 1) ms = 1;
             Sleep(ms);
         }
@@ -2454,12 +2622,15 @@ static DWORD WINAPI SunSDRKeepaliveThread(LPVOID param)
 
 /* ========== Exported functions ========== */
 
-int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort)
+int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort, int modelId)
 {
     WSADATA wsaData;
     int optval;
     MMRESULT tbp_rc;
     LARGE_INTEGER qpc_freq_check;
+    const sunsdr_profile_t* profile;
+    int resolvedCtrlPort;
+    int resolvedStreamPort;
 
     /* Explicitly start the async logger writer thread BEFORE any sdr_logf
      * calls, so we deterministically route through the non-blocking path.
@@ -2476,7 +2647,7 @@ int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort)
     tbp_rc = timeBeginPeriod(1);
     QueryPerformanceFrequency(&qpc_freq_check);
 
-    sdr_logf("SunSDRInit(%s, %d, %d)\n", radioIP, ctrlPort, streamPort);
+    sdr_logf("SunSDRInit(%s, %d, %d, model=%d)\n", radioIP, ctrlPort, streamPort, modelId);
     sdr_logf("TIMING_INIT: timeBeginPeriod(1) rc=%u (0=OK) qpcFreq=%lld\n",
         (unsigned)tbp_rc, (long long)qpc_freq_check.QuadPart);
 
@@ -2516,12 +2687,20 @@ int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort)
         sdr_logf("SunSDRInit() cleaning up previous session state before re-init\n");
         SunSDRDestroy();
     }
+    profile = sunsdr_pick_profile(modelId, ctrlPort, streamPort);
+    resolvedCtrlPort = (ctrlPort > 0) ? ctrlPort : profile->defaultCtrlPort;
+    resolvedStreamPort = (streamPort > 0) ? streamPort :
+        ((ctrlPort > 0) ? (ctrlPort + 1) : profile->defaultStreamPort);
     memset(&sdr, 0, sizeof(sdr));
     sdr.ctrlSock = INVALID_SOCKET;
     sdr.streamSock = INVALID_SOCKET;
     sdr.currentMode = -1;
-    sdr.ctrlPort = ctrlPort;
-    sdr.streamPort = streamPort;
+    sdr.ctrlPort = resolvedCtrlPort;
+    sdr.streamPort = resolvedStreamPort;
+    sdr.profile = profile;
+    sdr.variant = sdr.profile->variant;
+    sdr_logf("SunSDR profile selected: %s (ctrl=%d stream=%d magic=0x%02X rxRate=%.4f)\n",
+        sdr.profile->name, sdr.ctrlPort, sdr.streamPort, (unsigned)sdr.profile->magic0, sdr.profile->rxNativeRate);
     sdr.currentRxAntenna = 1;
     sdr.currentTxAntenna = 1;
     sunsdr_set_identity_defaults();
@@ -2550,10 +2729,10 @@ int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort)
     memset(&localAddr, 0, sizeof(localAddr));
     localAddr.sin_family = AF_INET;
     localAddr.sin_addr.s_addr = INADDR_ANY;
-    localAddr.sin_port = htons((u_short)ctrlPort);
+    localAddr.sin_port = htons((u_short)sdr.ctrlPort);
 
     if (bind(sdr.ctrlSock, (struct sockaddr*)&localAddr, sizeof(localAddr)) == SOCKET_ERROR) {
-        printf("SunSDR: failed to bind control socket to port %d\n", ctrlPort);
+        printf("SunSDR: failed to bind control socket to port %d\n", sdr.ctrlPort);
         closesocket(sdr.ctrlSock);
         sdr.ctrlSock = INVALID_SOCKET;
         return -2;
@@ -2575,10 +2754,10 @@ int SunSDRInit(const char* radioIP, int ctrlPort, int streamPort)
     memset(&localAddr, 0, sizeof(localAddr));
     localAddr.sin_family = AF_INET;
     localAddr.sin_addr.s_addr = INADDR_ANY;
-    localAddr.sin_port = htons((u_short)streamPort);
+    localAddr.sin_port = htons((u_short)sdr.streamPort);
 
     if (bind(sdr.streamSock, (struct sockaddr*)&localAddr, sizeof(localAddr)) == SOCKET_ERROR) {
-        printf("SunSDR: failed to bind stream socket to port %d\n", streamPort);
+        printf("SunSDR: failed to bind stream socket to port %d\n", sdr.streamPort);
         closesocket(sdr.ctrlSock);
         closesocket(sdr.streamSock);
         sdr.streamSock = INVALID_SOCKET;
@@ -2769,6 +2948,10 @@ int SunSDRPowerOn(void)
     sdr.txPrevI = 0.0;
     sdr.txPrevQ = 0.0;
     sdr.txAccumCount = 0;
+
+    /* PRO still uses the legacy RX upsample stage; clear its phase when a
+     * session starts so stale interpolation state cannot bleed across runs. */
+    memset(resampler, 0, sizeof(resampler));
 
     /* Dump audio state BEFORE any fixes */
     sunsdr_dump_audio_state("before-fix");
@@ -3712,9 +3895,9 @@ DWORD WINAPI SunSDRReadThread(LPVOID param)
      * whenever packets aren't arriving fast enough. This keeps WDSP's input rate constant.
      */
     int rx_stream_id = inid(0, 0);
-    int rx_resample_outsize = SUNSDR_IQ_COMPLEX_PER_PKT;  /* 200, native packet size (no resample) */
+    int rx_resample_outsize = sunsdr_rx_router_feed_size();
     double* rx_silence_buf = (double*)calloc(2 * rx_resample_outsize, sizeof(double));
-    double rx_feed_rate_target = 1562.5; /* expected packets/sec */
+    double rx_feed_rate_target = sunsdr_rx_packet_rate();
     double rx_silence_accum = 0.0;
     int prev_ptt_state = 0;
     ULONGLONG last_rx_pkt_tick = 0;
@@ -4003,7 +4186,7 @@ DWORD WINAPI SunSDRReadThread(LPVOID param)
         }
 
         /* Verify magic */
-        if (n < 4 || pktbuf[0] != SUNSDR_MAGIC_0 || pktbuf[1] != SUNSDR_MAGIC_1) {
+        if (n < 4 || pktbuf[0] != sunsdr_magic0() || pktbuf[1] != SUNSDR_MAGIC_1) {
             timeout_count++;
             continue;
         }
@@ -4179,32 +4362,39 @@ DWORD WINAPI SunSDRReadThread(LPVOID param)
 
         for (i = 0, k = 0; i < SUNSDR_IQ_COMPLEX_PER_PKT; i++, k += SUNSDR_IQ_BYTES_PER_IQ) {
             /* SunSDR 24-bit LE: byte[0]=LSB, byte[1]=MID, byte[2]=MSB */
-            /* Convert to 32-bit signed (MSB-aligned) then normalize to double */
-            /* NOTE: SunSDR sends Q first, I second (opposite of HPSDR) */
+            /* RX wire order on the observed DX/PRO stream is Q first, I second. */
             sdr.rxBuf[2 * i + 0] = NORM *
                 (double)((int)(payload[k + 5] << 24 |
                                payload[k + 4] << 16 |
-                               payload[k + 3] << 8));     /* I (from bytes 3-5) */
+                               payload[k + 3] << 8));     /* I (bytes 3-5) */
 
             sdr.rxBuf[2 * i + 1] = NORM *
                 (double)((int)(payload[k + 2] << 24 |
                                payload[k + 1] << 16 |
-                               payload[k + 0] << 8));     /* Q (from bytes 0-2) */
+                               payload[k + 0] << 8));     /* Q (bytes 0-2) */
         }
 
-        /* Feed native 312.5 kHz IQ directly to Thetis DSP pipeline (no resample) */
+        /* DX feeds WDSP natively at 312.5 kHz; PRO keeps the legacy
+         * resample step to 384 kHz. */
         {
             int active_sources = pktbuf[8];
             int source = 0;
+            int out_n = SUNSDR_IQ_COMPLEX_PER_PKT;
+            double* feed_buf = sdr.rxBuf;
 
             if (active_sources >= 2 && pktbuf[9] < 2)
                 source = pktbuf[9];
 
+            if (!sunsdr_rx_uses_native_router_rate()) {
+                out_n = sunsdr_resample(source, sdr.rxBuf, SUNSDR_IQ_COMPLEX_PER_PKT);
+                feed_buf = resampler[source].out;
+            }
+
             /* WDSP-ready gate: drop IQ dispatch until C# has configured
              * the WDSP RX channel (see SunSDRSetRxWdspReady). */
-            if (InterlockedAnd(&sdr.rxWdspReady, 0xffffffff)) {
+            if (out_n > 0 && InterlockedAnd(&sdr.rxWdspReady, 0xffffffff)) {
                 __try {
-                    xrouter(NULL, 0, source, SUNSDR_IQ_COMPLEX_PER_PKT, sdr.rxBuf);
+                    xrouter(NULL, 0, source, out_n, feed_buf);
                     if (source == 0) {
                         last_rx_pkt_tick = GetTickCount64();
                         dbg_xrouter_real_feeds++;
@@ -4217,15 +4407,15 @@ DWORD WINAPI SunSDRReadThread(LPVOID param)
                         }
                     }
                 } __except(EXCEPTION_EXECUTE_HANDLER) {
-                    sdr_logf("CRASH in xrouter at pkt %d (source=%d)! Exception=0x%08X\n",
-                        pkt_count, source, GetExceptionCode());
+                    sdr_logf("CRASH in xrouter at pkt %d (source=%d, out_n=%d)! Exception=0x%08X\n",
+                        pkt_count, source, out_n, GetExceptionCode());
                     Sleep(1000);
                     continue;
                 }
             }
             if (pkt_count == 1 || pkt_count == 100 || pkt_count % 5000 == 0)
                 sdr_logf("IQ pkts=%d, source=%d/%d, feed=%d samples, tx_sent=%d (HaveSync=%d)\n",
-                    pkt_count, source, active_sources, SUNSDR_IQ_COMPLEX_PER_PKT, sdr.txSeq, HaveSync);
+                    pkt_count, source, active_sources, out_n, sdr.txSeq, HaveSync);
         }
         pkt_count++;
 
@@ -4259,6 +4449,7 @@ static void sunsdr_probe_identity_query(void)
     if (len <= 0) {
         return;
     }
+    sunsdr_patch_magic(pkt, len);
 
     sunsdr_drain_control_socket("pre_probe");
     sunsdr_set_ctrl_trace_label("identity_probe");
@@ -4360,6 +4551,7 @@ static void sunsdr_query_firmware_manager_version(void)
     if (len <= 0) {
         return;
     }
+    sunsdr_patch_magic(pkt, len);
 
     sunsdr_drain_control_socket("pre_fwmgr");
     sunsdr_set_ctrl_trace_label("fwmgr_version");
@@ -4375,7 +4567,7 @@ static void sunsdr_query_firmware_manager_version(void)
     sdr_logf("FWMGR query reply: len=%d hex=%s\n", n, hexbuf);
 
     if (n >= 26 &&
-        reply[0] == 0x32 &&
+        reply[0] == sunsdr_magic0() &&
         reply[1] == 0xFF &&
         reply[2] == 0x1A &&
         reply[4] == 0x20 &&

--- a/Project Files/Source/ChannelMaster/sunsdr.h
+++ b/Project Files/Source/ChannelMaster/sunsdr.h
@@ -1,6 +1,6 @@
 /*  sunsdr.h
 
-SunSDR2 DX native protocol support for Thetis.
+SunSDR2 native protocol support for Thetis.
 
 This file is part of a program that implements a Software-Defined Radio.
 
@@ -110,6 +110,31 @@ of the License, or (at your option) any later version.
 
 /* ---------- State ---------- */
 
+typedef enum _sunsdr_variant
+{
+    SUNSDR_VARIANT_DX = 0,
+    SUNSDR_VARIANT_PRO = 1
+} sunsdr_variant_t;
+
+typedef struct _sunsdr_macro_step
+{
+    const char* hex;
+    int len;
+    int delay_us; /* microseconds */
+} sunsdr_macro_step_t;
+
+typedef struct _sunsdr_profile
+{
+    sunsdr_variant_t variant;
+    const char* name;
+    int defaultCtrlPort;
+    int defaultStreamPort;
+    unsigned char magic0;
+    double rxNativeRate;
+    int macroStartIqValue;
+    int macroMicSourceValue; /* <0 => use UI-selected source */
+} sunsdr_profile_t;
+
 typedef struct _sunsdr_state
 {
     /* Sockets */
@@ -121,6 +146,8 @@ typedef struct _sunsdr_state
     char radioIP[64];
     int ctrlPort;
     int streamPort;
+    sunsdr_variant_t variant;
+    const sunsdr_profile_t* profile;
 
     /* Thread handles */
     HANDLE hReadThread;
@@ -196,7 +223,7 @@ typedef struct _sunsdr_state
 /* ---------- Exported functions ---------- */
 
 /* Lifecycle */
-int  SunSDRInit(const char* radioIP, int ctrlPort, int streamPort);
+int  SunSDRInit(const char* radioIP, int ctrlPort, int streamPort, int modelId);
 void SunSDRDestroy(void);
 int  SunSDRPowerOn(void);
 void SunSDRPowerOff(void);

--- a/Project Files/Source/Console/AssemblyInfo.cs
+++ b/Project Files/Source/Console/AssemblyInfo.cs
@@ -67,9 +67,9 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("2.0.9.0")]
-[assembly: AssemblyFileVersion("2.0.9.0")]
-[assembly: AssemblyInformationalVersion("v2.0.9")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("v2.1.0.0-test")]
 
 //
 // In order to sign your assembly you must specify a key to use. Refer to the 

--- a/Project Files/Source/Console/HPSDR/NetworkIO.cs
+++ b/Project Files/Source/Console/HPSDR/NetworkIO.cs
@@ -107,7 +107,7 @@ namespace Thetis
             // the setup form's `initializing` flag during DB restore, so
             // without this explicit call the router is never SUNSDR-aware
             // and the first IQ packets feed the wrong WDSP inputs.
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX)
+            if (HardwareSpecific.IsCurrentSunSDRModel)
             {
                 protocol = (int)RadioProtocol.SUNSDR;
                 CurrentRadioProtocol = RadioProtocol.SUNSDR;

--- a/Project Files/Source/Console/HPSDR/clsRadioDiscovery.cs
+++ b/Project Files/Source/Console/HPSDR/clsRadioDiscovery.cs
@@ -513,6 +513,7 @@ namespace Thetis
         public IPAddress IpAddress { get; set; }
         public string MacAddress { get; set; }
         public HPSDRHW DeviceType { get; set; }
+        public string DisplayName { get; set; }
         public byte CodeVersion { get; set; }
         public byte BetaVersion { get; set; }
         public byte Protocol2Supported { get; set; }

--- a/Project Files/Source/Console/HPSDR/clsSunSDRDiscovery.cs
+++ b/Project Files/Source/Console/HPSDR/clsSunSDRDiscovery.cs
@@ -1,12 +1,13 @@
 /*  clsSunSDRDiscovery.cs
 
-SunSDR2 DX native-protocol discovery for Artemis.
+SunSDR native-protocol discovery for Artemis.
 
 The SunSDR2 DX does NOT answer HPSDR-style `effeeffe...` broadcasts. Its
 discovery path is a separate 24-byte UDP broadcast to port 50001 with
-header `32 ff 00 1a`. The radio replies with a 24-byte packet starting
-with `32 ff 01 1a` that carries the radio IP (bytes 10-13 big-endian)
-and the control port (bytes 18-19 little-endian, = 0xc351 = 50001).
+header `32 ff 00 1a`. SunSDR2 PRO uses the same packet layout but
+answers the `01 ff 00 1a` probe. The radio replies with a 24-byte packet
+starting with `XX ff 01 1a` that carries the radio IP (bytes 10-13
+big-endian) and the control port (bytes 18-19 little-endian).
 
 Wire layout confirmed from capture `20260311_151107_sunsdr2dx_discovery`:
   offset 0-3  : 32 ff 01 1a
@@ -35,17 +36,21 @@ namespace Thetis
         public const int DefaultControlPort = 50001;
         private const int QueryPacketLength = 24;
 
-        // Query magic: `32 ff 00 1a`. The `1a` byte is understood to be a
-        // model-family selector (confirmed 1a == SunSDR2 DX). Older SunSDR2
-        // variants may honour other values here; we broadcast the DX family
-        // query for now because that's the one we know is accepted.
-        private static readonly byte[] QueryMagic = new byte[] { 0x32, 0xff, 0x00, 0x1a };
-        // Reply magic: `32 ff 01 XX`. We only require the first 3 bytes to
-        // match — the XX model byte varies by radio family (SunSDR2 DX = 0x1a
-        // from our captures; SunSDR2 classic / PRO / QRP likely different).
-        // Accepting any fourth byte lets older SunSDR2 variants appear in
-        // the Discover list so we at least know they're on the wire.
-        private static readonly byte[] ReplyMagic = new byte[] { 0x32, 0xff, 0x01 };
+        // ExpertSDR3 probes several SunSDR families by varying byte 0 while
+        // keeping bytes 1..3 as `ff 00 1a`. Confirmed:
+        //   0x32 = SunSDR2 DX
+        //   0x01 = SunSDR2 PRO
+        private static readonly byte[] QueryFamilyBytes = new byte[] { 0x32, 0x01, 0x42, 0x22, 0x12, 0x03 };
+
+        private static string getDisplayName(byte familyByte)
+        {
+            switch (familyByte)
+            {
+                case 0x32: return "SunSDR2 DX";
+                case 0x01: return "SunSDR2 PRO";
+                default:   return "SunSDR";
+            }
+        }
 
         public List<RadioInfo> Probe(IPAddress localIp, int timeoutMs)
         {
@@ -70,9 +75,12 @@ namespace Thetis
                 sock.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 sock.Bind(new IPEndPoint(localIp, 0));
 
-                byte[] query = buildQueryPacket();
                 IPEndPoint dest = new IPEndPoint(IPAddress.Broadcast, targetPort);
-                sock.SendTo(query, dest);
+                foreach (byte family in QueryFamilyBytes)
+                {
+                    byte[] query = buildQueryPacket(family);
+                    sock.SendTo(query, dest);
+                }
 
                 byte[] rxBuf = new byte[1500];
                 DateTime deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
@@ -98,7 +106,7 @@ namespace Thetis
                     }
 
                     if (n < QueryPacketLength) continue;
-                    if (!matchesMagic(rxBuf, ReplyMagic)) continue;
+                    if (!isSunSDRDiscoveryReply(rxBuf)) continue;
 
                     IPEndPoint src = from as IPEndPoint;
                     if (src == null) continue;
@@ -106,13 +114,13 @@ namespace Thetis
                      * responds from its listen port which equals our target. */
                     if (src.Port != targetPort) continue;
 
-                    // Byte 3 is the model-family selector (0x1a confirmed
-                    // == SunSDR2 DX). Surface it via Debug so we can tell
-                    // what models are being discovered on different setups.
+                    byte familyByte = rxBuf[0];
                     byte modelByte = rxBuf[3];
                     System.Diagnostics.Debug.WriteLine(
                         "[SunSDRDiscovery] Reply from " + src.Address +
-                        ":" + src.Port + " modelByte=0x" + modelByte.ToString("x2"));
+                        ":" + src.Port +
+                        " familyByte=0x" + familyByte.ToString("x2") +
+                        " modelByte=0x" + modelByte.ToString("x2"));
 
                     IPAddress radioIp = parseIpBE(rxBuf, 10);
                     int port = rxBuf[18] | (rxBuf[19] << 8);
@@ -127,6 +135,7 @@ namespace Thetis
                         IpAddress = radioIp,
                         MacAddress = "",
                         DeviceType = HPSDRHW.SunSDR,
+                        DisplayName = getDisplayName(familyByte),
                         CodeVersion = 0,
                         BetaVersion = 0,
                         Protocol2Supported = 0,
@@ -155,10 +164,13 @@ namespace Thetis
             return found;
         }
 
-        private static byte[] buildQueryPacket()
+        private static byte[] buildQueryPacket(byte familyByte)
         {
             byte[] pkt = new byte[QueryPacketLength];
-            Buffer.BlockCopy(QueryMagic, 0, pkt, 0, QueryMagic.Length);
+            pkt[0] = familyByte;
+            pkt[1] = 0xff;
+            pkt[2] = 0x00;
+            pkt[3] = 0x1a;
             // Middle bytes 4..21 stay zero. Checksum at 22-23: sum of 16-bit LE
             // words over bytes 0..21, one's complement. Radios accept zero
             // checksum in practice, but compute it in case firmware gets stricter.
@@ -175,12 +187,13 @@ namespace Thetis
             return pkt;
         }
 
-        private static bool matchesMagic(byte[] buf, byte[] magic)
+        private static bool isSunSDRDiscoveryReply(byte[] buf)
         {
-            if (buf == null || buf.Length < magic.Length) return false;
-            for (int i = 0; i < magic.Length; i++)
-                if (buf[i] != magic[i]) return false;
-            return true;
+            return buf != null &&
+                   buf.Length >= QueryPacketLength &&
+                   buf[1] == 0xff &&
+                   buf[2] == 0x01 &&
+                   buf[3] == 0x1a;
         }
 
         private static IPAddress parseIpBE(byte[] buf, int offset)

--- a/Project Files/Source/Console/HPSDR/clsSunSDRDiscovery.cs
+++ b/Project Files/Source/Console/HPSDR/clsSunSDRDiscovery.cs
@@ -36,10 +36,15 @@ namespace Thetis
         public const int DefaultControlPort = 50001;
         private const int QueryPacketLength = 24;
 
-        // ExpertSDR3 probes several SunSDR families by varying byte 0 while
-        // keeping bytes 1..3 as `ff 00 1a`. Confirmed:
+        // Query magic: the original DX-only path used `32 ff 00 1a`.
+        // The `1a` byte is understood to be a model-family selector
+        // (confirmed 1a == SunSDR2 DX). ExpertSDR3 probes several SunSDR
+        // families by varying byte 0 while keeping bytes 1..3 as `ff 00 1a`.
+        // Confirmed:
         //   0x32 = SunSDR2 DX
         //   0x01 = SunSDR2 PRO
+        // Additional family bytes are probed so older SunSDR2 variants can
+        // at least appear in the Discover list if they respond on the wire.
         private static readonly byte[] QueryFamilyBytes = new byte[] { 0x32, 0x01, 0x42, 0x22, 0x12, 0x03 };
 
         private static string getDisplayName(byte familyByte)
@@ -114,6 +119,11 @@ namespace Thetis
                      * responds from its listen port which equals our target. */
                     if (src.Port != targetPort) continue;
 
+                    // Byte 0 is the family byte we varied in the query.
+                    // Byte 3 remains the model-family selector (0x1a confirmed
+                    // == SunSDR2 DX/PRO discovery family). Surface both via
+                    // Debug so we can tell what models are being discovered
+                    // on different setups.
                     byte familyByte = rxBuf[0];
                     byte modelByte = rxBuf[3];
                     System.Diagnostics.Debug.WriteLine(
@@ -189,6 +199,10 @@ namespace Thetis
 
         private static bool isSunSDRDiscoveryReply(byte[] buf)
         {
+            // Reply magic: `XX ff 01 1a`. The original DX path only required
+            // `32 ff 01` because the fourth model byte could vary by radio
+            // family. For multi-family probing, accept any byte 0 but keep the
+            // common `ff 01 1a` signature.
             return buf != null &&
                    buf.Length >= QueryPacketLength &&
                    buf[1] == 0xff &&

--- a/Project Files/Source/Console/audio.cs
+++ b/Project Files/Source/Console/audio.cs
@@ -1344,34 +1344,29 @@ namespace Thetis
             }
         }
 
+        private static int ComputeOutCount(int inputBlockSize, int inputRate, int outputRate)
+        {
+            if (inputBlockSize <= 0 || inputRate <= 0 || outputRate <= 0)
+                return inputBlockSize;
+
+            long scaled = (long)inputBlockSize * outputRate;
+            int count = (int)((scaled + (inputRate / 2L)) / inputRate); // round to nearest
+            return count > 0 ? count : 1;
+        }
+
         private static void SetOutCount()
         {
-            if (out_rate >= sample_rate1)
-                OutCount = block_size1 * (out_rate / sample_rate1);
-            else
-                OutCount = block_size1 / (sample_rate1 / out_rate);
+            OutCount = ComputeOutCount(block_size1, sample_rate1, out_rate);
         }
 
         private static void SetOutCountRX2()
         {
-            if (out_rate_rx2 >= sample_rate_rx2)
-                OutCountRX2 = block_size_rx2 * (out_rate_rx2 / sample_rate_rx2);
-            else
-                OutCountRX2 = block_size_rx2 / (sample_rate_rx2 / out_rate_rx2);
+            OutCountRX2 = ComputeOutCount(block_size_rx2, sample_rate_rx2, out_rate_rx2);
         }
 
         private static void SetOutCountTX()
         {
-            //if (out_rate_tx >= sample_rate_tx)
-            //    OutCountTX = block_size1 * (out_rate_tx / sample_rate_tx);
-            //else
-            //    OutCountTX = block_size1 / (sample_rate_tx / out_rate_tx);
-
-            //[2.10.3.4]MW0LGE changed to use tx block size
-            if (out_rate_tx >= sample_rate_tx)
-                OutCountTX = block_size_tx * (out_rate_tx / sample_rate_tx);
-            else
-                OutCountTX = block_size_tx / (sample_rate_tx / out_rate_tx);
+            OutCountTX = ComputeOutCount(block_size_tx, sample_rate_tx, out_rate_tx);
         }
 
         private static int out_count = 1024;

--- a/Project Files/Source/Console/clsDiscoveredRadioPicker.cs
+++ b/Project Files/Source/Console/clsDiscoveredRadioPicker.cs
@@ -325,7 +325,10 @@ namespace Thetis
                             //}
                         }
 
-                        int rowIndex = grid.Rows.Add(false, radio.DeviceType.ToString(), radio.IpAddress.ToString(), port.ToString(), radio.IsCustom ? "Custom" : radio.MacAddress, protocol, version);
+                        string hardware = !string.IsNullOrWhiteSpace(radio.DisplayName)
+                            ? radio.DisplayName
+                            : radio.DeviceType.ToString();
+                        int rowIndex = grid.Rows.Add(false, hardware, radio.IpAddress.ToString(), port.ToString(), radio.IsCustom ? "Custom" : radio.MacAddress, protocol, version);
                         DataGridViewRow row = grid.Rows[rowIndex];
 
                         RowRef rr = new RowRef();

--- a/Project Files/Source/Console/clsHardwareSpecific.cs
+++ b/Project Files/Source/Console/clsHardwareSpecific.cs
@@ -67,6 +67,16 @@ namespace Thetis
             _old_hardware = HPSDRHW.Unknown;
         }
 
+        public static bool IsSunSDRModel(HPSDRModel model)
+        {
+            return model == HPSDRModel.SUNSDR2DX || model == HPSDRModel.SUNSDR2PRO;
+        }
+
+        public static bool IsCurrentSunSDRModel
+        {
+            get { return IsSunSDRModel(_model); }
+        }
+
         #region MODEL
         // model
         public static HPSDRModel Model
@@ -183,6 +193,7 @@ namespace Thetis
                         HardwareSpecific.Hardware = HPSDRHW.OrionMKII;
                         break;
                     case HPSDRModel.SUNSDR2DX:
+                    case HPSDRModel.SUNSDR2PRO:
                         NetworkIO.SetRxADC(1);
                         NetworkIO.SetMKIIBPF(0);
                         cmaster.SetADCSupply(0, 33);
@@ -354,6 +365,8 @@ namespace Thetis
                     return HPSDRModel.REDPITAYA;
                 case "SUNSDR2-DX":
                     return HPSDRModel.SUNSDR2DX;
+                case "SUNSDR2-PRO":
+                    return HPSDRModel.SUNSDR2PRO;
                 default:
                     return HPSDRModel.HERMES;
             }
@@ -392,6 +405,8 @@ namespace Thetis
                     return "RED-PITAYA";
                 case HPSDRModel.SUNSDR2DX:
                     return "SUNSDR2-DX";
+                case HPSDRModel.SUNSDR2PRO:
+                    return "SUNSDR2-PRO";
                 default:
                     return "HERMES";
             }
@@ -435,6 +450,17 @@ namespace Thetis
                     //     + rx_meter_cal_offset_by_radio array)
                     //   - memory/project_smeter_reference_20260422.md
                     return 18.98f;
+                case HPSDRModel.SUNSDR2PRO:
+                    // Experimental anchor from @Tort1k558's PR #30 initial
+                    // SunSDR2 PRO bring-up — direct comparison against
+                    // ExpertSDR3 in Signal mode on 40 m at +10 dB preamp
+                    // landed on ~+7 dB over the generic fall-through. Not
+                    // yet cross-validated against EESDR3 the same way DX
+                    // was at -94.5 dBm / S6 + ¼, so treat this value as
+                    // a starting point; PRO users should fine-tune via
+                    // Setup → Tests → Level Cal once they have a known
+                    // reference signal.
+                    return 6.98f;
                 default:
                     return 0.98f;
             }
@@ -653,6 +679,7 @@ namespace Thetis
                     return gains;
 
                 case HPSDRModel.SUNSDR2DX:
+                case HPSDRModel.SUNSDR2PRO:
                     /*
                      * SunSDR2 DX uses the native TX path rather than the HPSDR DAC/output
                      * chain. In practice it needs a materially lower PA attenuation baseline

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -20500,11 +20500,17 @@ namespace Thetis
 
         private int sample_rate_rx1 = 0; //[2.10.2.3]MW0LGE change to 0 so that comboAudioSampleRate1_SelectedIndexChanged will do its thing is system is shutdown with 48000 selected
         private int m_nOldSampleRateRX1 = 0;
+        private static int ClampSunSDRSampleRate(int rate)
+        {
+            return HardwareSpecific.IsCurrentSunSDRModel ? 312500 : rate;
+        }
+
         public int SampleRateRX1
         {
             get { return sample_rate_rx1; }
             set
             {
+                value = ClampSunSDRSampleRate(value);
                 m_nOldSampleRateRX1 = sample_rate_rx1;
 
                 sample_rate_rx1 = value;
@@ -20546,6 +20552,7 @@ namespace Thetis
             get { return sample_rate_rx2; }
             set
             {
+                value = ClampSunSDRSampleRate(value);
                 m_nOldSampleRateRX2 = sample_rate_rx2;
 
                 sample_rate_rx2 = value;

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -740,12 +740,32 @@ namespace Thetis
             }
             LogTool.AddLogEntry("Directories ok");
 
-            // Splash: show just "ArtemisSDR <version>" — no radio-model
-            // suffix. BUILD_NAME was "SunSDR2 DX" which stops being true
-            // once PRO support ships. The About dialog still surfaces the
-            // build name per-radio; the splash is a brand line, not a
-            // model label.
-            Splash.ShowSplashScreen("ArtemisSDR " + Common.GetVerNum(true, false), splash_screen_folder);
+            // Splash: show "ArtemisSDR <InformationalVersion>" — e.g.
+            // "ArtemisSDR v2.1.0.0-test" on the feature/sunsdr2-pro
+            // preview build, "ArtemisSDR v2.1.0" on a stable release.
+            //
+            // Using the InformationalVersion (ProductVersion on the PE)
+            // preserves the 'v' prefix and any suffix like '-test' or
+            // '-beta' that gets set in AssemblyInfo.cs. Common.GetVerNum
+            // reads AssemblyFileVersion which is strictly numeric and
+            // drops those markers.
+            //
+            // BUILD_NAME used to append "SunSDR2 DX" here, which stops
+            // being true once PRO support ships. The About dialog still
+            // surfaces the build name per-radio; the splash is a brand
+            // line, not a model label.
+            string splashVer;
+            try
+            {
+                splashVer = System.Diagnostics.FileVersionInfo
+                    .GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location)
+                    .ProductVersion;
+            }
+            catch
+            {
+                splashVer = Common.GetVerNum(true, false);
+            }
+            Splash.ShowSplashScreen("ArtemisSDR " + splashVer, splash_screen_folder);
 
             LogTool.AddLogEntry("Splash screen shown");
 

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -4094,19 +4094,21 @@ namespace Thetis
                     case "rx1_meter_cal_offset":
                         {
                             float loaded = float.Parse(val);
-                            // One-time migration for SunSDR2 DX. Two legacy
+                            // One-time migration for SunSDR2 family. Two legacy
                             // values trip the upgrade: the pre-v2.0.7 fall-
-                            // through default of 0.98 dB, and the v2.0.7
+                            // through default of 0.98 dB, and the v2.0.7 DX
                             // coarse-anchor value of 6.98 dB (which turned
-                            // out to still be ~12 dB low vs EESDR3). Both
-                            // get lifted to whatever the current SUNSDR2DX
+                            // out to still be ~12 dB low vs EESDR3 on DX).
+                            // Both get lifted to whatever the current model
                             // default is. Customised values outside these
-                            // two known-bad points are left alone.
-                            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX
+                            // two known-bad points are left alone. Applies
+                            // to both SUNSDR2DX and SUNSDR2PRO via
+                            // IsCurrentSunSDRModel.
+                            if (HardwareSpecific.IsCurrentSunSDRModel
                                 && (Math.Abs(loaded - 0.98f) < 0.01f
                                     || Math.Abs(loaded - 6.98f) < 0.01f))
                             {
-                                loaded = HardwareSpecific.RXMeterCalbrationOffsetDefaults(HPSDRModel.SUNSDR2DX);
+                                loaded = HardwareSpecific.RXMeterCalbrationOffsetDefaults(HardwareSpecific.Model);
                             }
                             RX1MeterCalOffset = loaded;
                         }
@@ -4117,11 +4119,11 @@ namespace Thetis
                     case "rx2_meter_cal_offset":
                         {
                             float loaded = float.Parse(val);
-                            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX
+                            if (HardwareSpecific.IsCurrentSunSDRModel
                                 && (Math.Abs(loaded - 0.98f) < 0.01f
                                     || Math.Abs(loaded - 6.98f) < 0.01f))
                             {
-                                loaded = HardwareSpecific.RXMeterCalbrationOffsetDefaults(HPSDRModel.SUNSDR2DX);
+                                loaded = HardwareSpecific.RXMeterCalbrationOffsetDefaults(HardwareSpecific.Model);
                                 System.Diagnostics.Debug.WriteLine("[SunSDR migration] rx2_meter_cal_offset legacy -> " + loaded);
                             }
                             RX2MeterCalOffset = loaded;
@@ -5897,7 +5899,7 @@ namespace Thetis
 
         private void EnableAllBands()
         {
-            bool sunsdr = HardwareSpecific.Model == HPSDRModel.SUNSDR2DX;
+            bool sunsdr = HardwareSpecific.IsCurrentSunSDRModel;
             foreach (Control c in panelBandHF.Controls)
             {
                 if (c is RadioButtonTS b)
@@ -6629,7 +6631,7 @@ namespace Thetis
         // SetupForHPSDRModel is not called on plain startup.
         private void ApplySunSDRSpecificUI()
         {
-            if (HardwareSpecific.Model != HPSDRModel.SUNSDR2DX) return;
+            if (!HardwareSpecific.IsCurrentSunSDRModel) return;
 
             if (chkFWCATUBypass.Checked)
                 chkFWCATUBypass.Checked = false;
@@ -6677,6 +6679,8 @@ namespace Thetis
                 RefreshFMFilterButtonLabels(true);
             if (_rx2_dsp_mode == DSPMode.FM)
                 RefreshFMFilterButtonLabels(false);
+
+            UpdateFMButtonLabels();
         }
 
         private void RefreshFMFilterButtonLabels(bool rx1)
@@ -15419,6 +15423,13 @@ namespace Thetis
                 RX2DisplayCalOffset = rx_display_cal_offset_by_radio[HardwareSpecific.ModelInt];
             }
 
+            // SunSDR widens the legal RX ceiling far above the legacy
+            // 61.44 MHz default. When switching models, validate the VFO
+            // against the correct ceiling first; otherwise a 2m frequency
+            // gets clipped to 61.44 before the SunSDR UI override runs.
+            if (HardwareSpecific.IsCurrentSunSDRModel)
+                ApplySunSDRSpecificUI();
+
             if (!IsSetupFormNull && HardwareSpecific.OldModel != HardwareSpecific.Model)
                 txtVFOAFreq_LostFocus(this, EventArgs.Empty);
 
@@ -15863,7 +15874,7 @@ namespace Thetis
                     chkPower.Checked)
                     chkMOX.Enabled = !_rx_only;
                 chkTUN.Enabled = !_rx_only;
-                chk2TONE.Enabled = !_rx_only && HardwareSpecific.Model != HPSDRModel.SUNSDR2DX; // MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
+                chk2TONE.Enabled = !_rx_only && !HardwareSpecific.IsCurrentSunSDRModel; // MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
                 chkVOX.Enabled = !_rx_only;
                 if (_rx_only && chkMOX.Checked)
                     chkMOX.Checked = false;
@@ -15894,7 +15905,7 @@ namespace Thetis
                     chkMOX.Enabled = !_tx_inhibit;
 
                 chkTUN.Enabled = !_tx_inhibit;
-                chk2TONE.Enabled = !_tx_inhibit && HardwareSpecific.Model != HPSDRModel.SUNSDR2DX; //MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
+                chk2TONE.Enabled = !_tx_inhibit && !HardwareSpecific.IsCurrentSunSDRModel; //MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
                 chkVOX.Enabled = !_tx_inhibit;
 
                 if ((_rx1_dsp_mode == DSPMode.CWL ||
@@ -21190,7 +21201,7 @@ namespace Thetis
             set
             {
                 xvtr_present = value;
-                bool sunsdr = HardwareSpecific.Model == HPSDRModel.SUNSDR2DX;
+                bool sunsdr = HardwareSpecific.IsCurrentSunSDRModel;
                 radBand2.Enabled = value || sunsdr;
                 //   Hdw.XVTRPresent = value;
                 if (sunsdr)
@@ -25703,7 +25714,7 @@ namespace Thetis
             // u16 ∝ RF voltage at directional coupler, power ∝ V^2
             // Calibration points (40m, external wattmeter):
             //   u16≈85 → 11W, u16≈142 → 50W, u16≈186 → 96W
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX)
+            if (HardwareSpecific.IsCurrentSunSDRModel)
             {
                 adc = NetworkIO.getFwdPower();
                 double v = Math.Max(0.0, adc - 33.0);
@@ -28096,7 +28107,7 @@ namespace Thetis
                 {
                     chkMOX.Enabled = true;
                     chkTUN.Enabled = true;
-                    chk2TONE.Enabled = HardwareSpecific.Model != HPSDRModel.SUNSDR2DX; //MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
+                    chk2TONE.Enabled = !HardwareSpecific.IsCurrentSunSDRModel; //MW0LGE_21a — 2TONE is PS-A-only, not supported on SunSDR
                 }
                 chkVFOLock.Enabled = true;
                 chkVFOBLock.Enabled = true;
@@ -29110,7 +29121,7 @@ namespace Thetis
             // paths and just push the state to the radio via OP 0x05.
             // state index maps to wire byte: 0 -> 0x80 (-20 dB atten),
             // 1 -> 0x81 (-10 dB), 2 -> 0x82 (bypass), 3 -> 0x83 (+10 dB preamp).
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX)
+            if (HardwareSpecific.IsCurrentSunSDRModel)
             {
                 int sunsdrState = -1;
                 switch (comboPreamp.Text)
@@ -41897,6 +41908,7 @@ namespace Thetis
                     comboPreamp.Items.AddRange(anan100d_preamp_settings);
                     break;
                 case HPSDRModel.SUNSDR2DX:
+                case HPSDRModel.SUNSDR2PRO:
                     // Four-state cycle: +10 dB preamp / 0 / -10 / -20. Wire
                     // delivery is handled in comboPreamp_SelectedIndexChanged
                     // via nativeSunSDRSetPreampAtt (OP 0x05). See
@@ -46925,7 +46937,7 @@ namespace Thetis
                 // B2M is globally classified as BandType.VHF which would
                 // swap the panel to the legacy XVTR VHF slots and hide
                 // our 2 button. Keep the HF panel visible instead.
-                if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX &&
+                if (HardwareSpecific.IsCurrentSunSDRModel &&
                     newBand == Band.B2M)
                     bt = BandType.HF;
 
@@ -47094,7 +47106,7 @@ namespace Thetis
             // button to engage external PA control whenever they want.
             // (The HPSDR path still gates visibility on OC Control pin
             //  configuration as before.)
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX)
+            if (HardwareSpecific.IsCurrentSunSDRModel)
                 bShow = true;
 
             if (bShow)

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -740,7 +740,12 @@ namespace Thetis
             }
             LogTool.AddLogEntry("Directories ok");
 
-            Splash.ShowSplashScreen("ArtemisSDR " + Common.GetVerNum(true, true), splash_screen_folder);							// Start splash screen with version number
+            // Splash: show just "ArtemisSDR <version>" — no radio-model
+            // suffix. BUILD_NAME was "SunSDR2 DX" which stops being true
+            // once PRO support ships. The About dialog still surfaces the
+            // build name per-radio; the splash is a brand line, not a
+            // model label.
+            Splash.ShowSplashScreen("ArtemisSDR " + Common.GetVerNum(true, false), splash_screen_folder);
 
             LogTool.AddLogEntry("Splash screen shown");
 

--- a/Project Files/Source/Console/enums.cs
+++ b/Project Files/Source/Console/enums.cs
@@ -128,6 +128,7 @@ namespace Thetis
         HERMESLITE,     //MI0BOT
         REDPITAYA,      //DH1KLM
         SUNSDR2DX,      // SunSDR2 DX native
+        SUNSDR2PRO,     // SunSDR2 PRO native
         LAST
     }
 

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -865,7 +865,7 @@ namespace Thetis
             int[] p1_rates = include_extra_p1_rate ? new int[] { 48000, 96000, 192000, 384000 } : new int[] { 48000, 96000, 192000 };
             int[] p2_rates = { 48000, 96000, 192000, 384000, 768000, 1536000 };
             int[] sunsdr_dx_rates = { 312500 }; // DX: native 312.5 kHz router path
-            int[] sunsdr_pro_rates = { 384000 }; // PRO: 39.0625 -> 384 kHz upsample path
+            int[] sunsdr_pro_rates = { 312500 }; // PRO uses the same native 312.5 kHz router path as DX
 
             int[] rates = HardwareSpecific.Model == HPSDRModel.SUNSDR2DX ? sunsdr_dx_rates :
                           HardwareSpecific.Model == HPSDRModel.SUNSDR2PRO ? sunsdr_pro_rates :

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -36595,6 +36595,47 @@ namespace Thetis
                     break;
             }
 
+            // Auto-sync the Radio Model dropdown to match the selected
+            // discovered radio's family, so a user who picked the wrong
+            // model from the dropdown before running Discovery doesn't
+            // end up talking to the radio with the wrong protocol.
+            //
+            // Example of the bug this closes: pick "SUNSDR2-PRO" from the
+            // dropdown → click Discover → the multi-family probe finds a
+            // SunSDR2 DX → user selects it in the list → without this
+            // sync, Model stays on "SUNSDR2-PRO" and Artemis tries to
+            // drive a DX with the PRO wire profile, which fails.
+            //
+            // Discovery result is the source of truth when Discovery is
+            // used; the dropdown is the fallback for manual entry. We
+            // only touch the dropdown if the selected discovered radio
+            // clearly belongs to a different model than what's chosen.
+            RadioInfo details = ucRadioList_Radios.SelectedRadioDetails;
+            if (details != null && !string.IsNullOrWhiteSpace(details.DisplayName))
+            {
+                string dn = details.DisplayName;
+                string targetModel = null;
+                if (dn.IndexOf("PRO", StringComparison.OrdinalIgnoreCase) >= 0
+                    && dn.IndexOf("SunSDR", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    targetModel = "SUNSDR2-PRO";
+                }
+                else if (dn.IndexOf("DX", StringComparison.OrdinalIgnoreCase) >= 0
+                         && dn.IndexOf("SunSDR", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    targetModel = "SUNSDR2-DX";
+                }
+
+                if (targetModel != null
+                    && comboRadioModel.Items.Contains(targetModel)
+                    && !string.Equals(comboRadioModel.Text, targetModel, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Setting .Text cascades through comboRadioModel_SelectedIndexChanged
+                    // -> HardwareSpecific.Model update -> initHPSDR -> all downstream UI.
+                    comboRadioModel.Text = targetModel;
+                }
+            }
+
             UpdateDDCTab();
             InitAudioTab();
         }

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -864,9 +864,11 @@ namespace Thetis
 
             int[] p1_rates = include_extra_p1_rate ? new int[] { 48000, 96000, 192000, 384000 } : new int[] { 48000, 96000, 192000 };
             int[] p2_rates = { 48000, 96000, 192000, 384000, 768000, 1536000 };
-            int[] sunsdr_rates = { 312500 }; // SunSDR2 DX: native 312.5 kHz rate, no resample stage
+            int[] sunsdr_dx_rates = { 312500 }; // DX: native 312.5 kHz router path
+            int[] sunsdr_pro_rates = { 384000 }; // PRO: 39.0625 -> 384 kHz upsample path
 
-            int[] rates = HardwareSpecific.Model == HPSDRModel.SUNSDR2DX ? sunsdr_rates :
+            int[] rates = HardwareSpecific.Model == HPSDRModel.SUNSDR2DX ? sunsdr_dx_rates :
+                          HardwareSpecific.Model == HPSDRModel.SUNSDR2PRO ? sunsdr_pro_rates :
                           NetworkIO.CurrentRadioProtocol == RadioProtocol.ETH ? p2_rates : p1_rates;
 
             foreach (int rate in rates)
@@ -23690,9 +23692,9 @@ namespace Thetis
              * Treat that legacy all-100 state as "uninitialized" for SunSDR and
              * fall back to the model defaults until the user recalibrates.
              */
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX && gain >= 99.0f)
+            if (HardwareSpecific.IsCurrentSunSDRModel && gain >= 99.0f)
             {
-                float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HPSDRModel.SUNSDR2DX);
+                float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HardwareSpecific.Model);
                 if ((int)b > (int)Band.FIRST && (int)b < (int)Band.LAST)
                     gain = defaults[(int)b] - GetSunSDRDefaultAdjust(nDriveValue);
             }
@@ -23704,7 +23706,7 @@ namespace Thetis
              * legacy baseline to the current SunSDR defaults until the operator
              * recalibrates the profile.
              */
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX &&
+            if (HardwareSpecific.IsCurrentSunSDRModel &&
                 (int)b > (int)Band.FIRST && (int)b < (int)Band.LAST)
             {
                 float[] legacy = new float[(int)Band.LAST];
@@ -23722,7 +23724,7 @@ namespace Thetis
 
                 if (Math.Abs(gain - legacy[(int)b]) < 0.2f)
                 {
-                    float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HPSDRModel.SUNSDR2DX);
+                    float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HardwareSpecific.Model);
                     gain = defaults[(int)b] - GetSunSDRDefaultAdjust(nDriveValue);
                 }
             }
@@ -23734,13 +23736,13 @@ namespace Thetis
              * no-offset SunSDR profile shape as legacy too and map it to the
              * current SunSDR defaults plus the built-in low-power compensation.
              */
-            if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX &&
+            if (HardwareSpecific.IsCurrentSunSDRModel &&
                 zero_adjust_curve &&
                 (int)b > (int)Band.FIRST && (int)b < (int)Band.LAST)
             {
                 if (Math.Abs(gain - sunsdrCurrent[(int)b]) < 0.2f)
                 {
-                    float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HPSDRModel.SUNSDR2DX);
+                    float[] defaults = HardwareSpecific.DefaultPAGainsForBands(HardwareSpecific.Model);
                     gain = defaults[(int)b] - GetSunSDRDefaultAdjust(nDriveValue);
                 }
             }
@@ -36387,7 +36389,7 @@ namespace Thetis
                  * IP:port (e.g. 10.0.3.50:40001) — the parser honours the
                  * port and network.c passes it through to SunSDRInit
                  * (fix for issue #15). */
-                if (HardwareSpecific.Model == HPSDRModel.SUNSDR2DX)
+                if (HardwareSpecific.IsCurrentSunSDRModel)
                 {
                     SunSDRDiscoveryService sunsdrSvc = new SunSDRDiscoveryService();
                     foreach (NicRadioScanResult nic in discovered)

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -8638,7 +8638,8 @@
             this.comboRadioModel.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboRadioModel.FormattingEnabled = true;
             this.comboRadioModel.Items.AddRange(new object[] {
-            "SUNSDR2-DX"});
+            "SUNSDR2-DX",
+            "SUNSDR2-PRO"});
             this.comboRadioModel.Location = new System.Drawing.Point(6, 19);
             this.comboRadioModel.Name = "comboRadioModel";
             this.comboRadioModel.Size = new System.Drawing.Size(136, 23);

--- a/Project Files/Source/Console/ucRadioList.cs
+++ b/Project Files/Source/Console/ucRadioList.cs
@@ -365,6 +365,12 @@ HPSDRHW hw = (HPSDRHW)0;
                 }
 
                 info.DeviceType = hw;
+                // Propagate the discovery-time DisplayName ("SunSDR2 DX" /
+                // "SunSDR2 PRO" / etc.) out to callers so they can auto-sync
+                // the Radio Model dropdown to match the selected discovered
+                // radio. Without this, HPSDRHW.SunSDR doesn't distinguish DX
+                // from PRO — the specific model only lives in the string.
+                info.DisplayName = model;
 
                 info.CodeVersion = item.RadioCodeVersion;
                 info.BetaVersion = item.RadioBetaVersion;

--- a/Project Files/Source/Console/ucRadioList.cs
+++ b/Project Files/Source/Console/ucRadioList.cs
@@ -360,7 +360,7 @@ HPSDRHW hw = (HPSDRHW)0;
                     }
                     catch
                     {
-                        hw = (HPSDRHW)0;
+                        hw = model.StartsWith("SunSDR", StringComparison.OrdinalIgnoreCase) ? HPSDRHW.SunSDR : (HPSDRHW)0;
                     }
                 }
 
@@ -632,7 +632,7 @@ HPSDRHW hw = (HPSDRHW)0;
             item.NicStatus = nic.NicStatus;
             item.NicMtu = nic.Mtu;
 
-            item.RadioModel = radio.DeviceType.ToString();
+            item.RadioModel = string.IsNullOrWhiteSpace(radio.DisplayName) ? radio.DeviceType.ToString() : radio.DisplayName;
             item.RadioIp = (radioIp != null) ? radioIp.ToString() : "";
             item.RadioPort = port;
             item.RadioProtocol = radio.Protocol;


### PR DESCRIPTION
Hi Kosta,

First of all, thank you for ArtemisSDR and for all the SunSDR native work already done in the project.

I spent an evening trying to add basic SunSDR2 PRO support on top of the existing SunSDR native implementation.

This is not a polished or final implementation. I’m not deeply experienced in this protocol area, so some parts may be wrong or incomplete. I mostly tried to get an initial working version together and share it instead of keeping it local.

Current status on my side:
- SunSDR2 PRO is detected
- the radio connects
- receive works for me
- transmit also works for me
- basic operation is possible

Known concerns:
- some parts may be implemented incorrectly
- I may have missed important protocol details
- display / spectrum behavior may still need work
- there may be regressions or things that are not handled properly yet
- before v2.0.8 the spectrum display looked more or less normal on my side, but after the latest evening update / changes around v2.0.8 it started looking incorrect

Also, I did not have a chance to test any of this on a SunSDR2 DX, so I cannot say whether I may have broken anything on the DX side.

So please treat this PR as an experimental starting point for SunSDR2 PRO support rather than a finished feature.

I understand this may need cleanup, review, or even partial rewriting. I just wanted to provide what I managed to get working so it can be checked, improved, or used as a reference.

If you can point me in the right direction or explain what parts look wrong, I can try to fix them in my free time and continue testing on my SunSDR2 PRO.

Thanks again.
